### PR TITLE
create ft employees can comment on other employees article

### DIFF
--- a/api/controllers/commentController.js
+++ b/api/controllers/commentController.js
@@ -1,0 +1,29 @@
+import ResponseGenerator from '../utilities/responseUtilities';
+import CommentService from '../services/commentService';
+
+const response = new ResponseGenerator();
+
+class CommentController {
+  /**
+     * @param {object} request express request object
+     * @param {object} response express request object
+     * @returns {json} json
+     * @memberof UserController
+     */
+
+  static async createComment(req, res) {
+    try {
+      const comment = await CommentService.addComment(req);
+
+      if (comment) {
+        return response.sendSuccess(res, 201, comment);
+      }
+      return response.sendError(res, 500, 'Something went wrong');
+    } catch (err) {
+      return response.sendError(res, 400, err.message);
+    }
+  }
+}
+
+
+export default CommentController;

--- a/api/models/CommentModel.js
+++ b/api/models/CommentModel.js
@@ -1,0 +1,33 @@
+import Query from '../utilities/psqlUtilities';
+
+class Comment extends Query {
+  async createComment(req) {
+    try {
+      const { rows } = await this.insertIntoDB(
+        'authorid, feedid, comment, flagged',
+        '$1, $2, $3, $4',
+        [
+          req.userId,
+          req.params.articleId,
+          req.body.comment,
+          false
+        ]
+      );
+      const article = await this.findByOneArticle(
+        'feedid',
+        [rows[0].feedid]
+      );
+      return {
+        message: 'Comment successfully created',
+        articleTitle: article.rows[0].title,
+        article: article.rows[0].article,
+        comment: rows[0].comment,
+        createdOn: rows[0].createdon
+      };
+    } catch (err) {
+      throw err;
+    }
+  }
+}
+
+export default Comment;

--- a/api/models/articleModel.js
+++ b/api/models/articleModel.js
@@ -1,4 +1,3 @@
-import { threadId } from 'worker_threads';
 import Query from '../utilities/psqlUtilities';
 
 class Article extends Query {
@@ -75,7 +74,7 @@ class Article extends Query {
         id: rows[0].feedid,
         createdOn: rows[0].createdon,
         title: rows[0].title,
-        artcle: rows[0].artcle,
+        artcle: rows[0].article,
         comments: [
           {
             commentId: comment.rows[0].commentid,

--- a/api/routes/articleRoute.js
+++ b/api/routes/articleRoute.js
@@ -2,9 +2,11 @@ import express from 'express';
 import articleController from '../controllers/articleController';
 import authMiddleware from '../middlewares/authMiddleware';
 import bodyValidation from '../middlewares/validation/bodyValidation';
+import commentRoute from './commentRoute';
 
 
 const router = express.Router();
+router.use('/articles/:articleId/comments', commentRoute);
 
 router.post(
   '/articles',

--- a/api/routes/commentRoute.js
+++ b/api/routes/commentRoute.js
@@ -1,0 +1,15 @@
+import express from 'express';
+import commentController from '../controllers/commentController';
+import authMiddleware from '../middlewares/authMiddleware';
+
+
+const router = express.Router({ mergeParams: true });
+
+router.post(
+  '/',
+  authMiddleware.authenticate,
+  commentController.createComment
+);
+
+
+export default router;

--- a/api/services/commentService.js
+++ b/api/services/commentService.js
@@ -1,0 +1,16 @@
+import CommentModel from '../models/commentModel';
+
+const Comment = new CommentModel('comments');
+
+class CommentService {
+  static async addComment(req) {
+    try {
+      const newComment = await Comment.createComment(req);
+      return newComment;
+    } catch (err) {
+      throw err;
+    }
+  }
+}
+
+export default CommentService;


### PR DESCRIPTION
Description
As an Employee, I should be able to comment on other employees  articles on the app

Acceptance Criteria
Given An Employee
When Employee makes a **POST** request to comment on an articles endpoint (/api/v1/articles/articleId/comments)
Then Employee should get a response with status code 201 and response structure



```

{
    "status": "success",
    "data": {
        "message": "Comment successfully created",
        "articleTitle": "birtday party",
        "article": "come and celebrate with me",
        "comment": "Incredible",
        "createdOn": "2019-11-13T11:56:17.014Z"
    }
}

```